### PR TITLE
Add GSO support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.user
+*.vscode
+build/

--- a/README.md
+++ b/README.md
@@ -20,16 +20,17 @@ server
 starting server on port 18080
 got new connection
 request received, sending data
-connection 0 second 0 send window: 410688458
-connection 0 second 1 send window: 825786506
-connection 0 second 2 send window: 1301139487
-connection 0 second 3 send window: 1781791568
-connection 0 second 4 send window: 1295055881
-connection 0 second 5 send window: 1295055881
-connection 0 second 6 send window: 634578277
-connection 0 second 7 send window: 634578277
-connection 0 second 8 send window: 444205689
-connection 0 second 9 send window: 444206969
+connection 0 second 0 send window: 1112923 packets sent: 364792 packets lost: 373
+connection 0 second 1 send window: 1238055 packets sent: 377515 packets lost: 123
+connection 0 second 2 send window: 583352 packets sent: 355482 packets lost: 862
+connection 0 second 3 send window: 275563 packets sent: 367538 packets lost: 607
+connection 0 second 4 send window: 1100261 packets sent: 366005 packets lost: 20
+connection 0 second 5 send window: 633010 packets sent: 356021 packets lost: 857
+connection 0 second 6 send window: 1266610 packets sent: 367866 packets lost: 0
+connection 0 second 7 send window: 1668530 packets sent: 360649 packets lost: 0
+connection 0 second 8 send window: 1994930 packets sent: 364087 packets lost: 0
+connection 0 second 9 send window: 1779683 packets sent: 374804 packets lost: 80
+connection 0 total packets sent: 3654759 total packets lost: 2922
 ```
 *Note*: The server looks for a TLS certificate and key in the current working dir named "server.crt" and "server.key" respectively. You can use a self signed certificate; the client doesn't validate it.
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@ Uses https://github.com/h2o/quicly
 Usage: ./qperf [options]
 
 Options:
+  -c target       run as client and connect to target server
+  -e              measure time for connection establishment and first byte only
+  -g              enable UDP generic segmentation offload
   -p              port to listen on/connect to (default 18080)
   -s              run as server
-  -c target       run as client and connect to target server
   -t time (s)     run for X seconds (default 10s)
-  -e              measure time for connection establishment and first byte only
   -h              print this help
 ```
 
 server
 ```
 ./qperf -s
-starting server on port 18080
+starting server with pid 5624 on port 18080
 got new connection
 request received, sending data
 connection 0 second 0 send window: 1112923 packets sent: 364792 packets lost: 373

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ server
 starting server on port 18080
 got new connection
 request received, sending data
-connection 0 second 0 send window: 410688458
-connection 0 second 1 send window: 825786506
-connection 0 second 2 send window: 1301139487
-connection 0 second 3 send window: 1781791568
-connection 0 second 4 send window: 1295055881
-connection 0 second 5 send window: 1295055881
-connection 0 second 6 send window: 634578277
-connection 0 second 7 send window: 634578277
-connection 0 second 8 send window: 444205689
-connection 0 second 9 send window: 444206969
+connection 0 second 0 send window: 1112923 packets sent: 364792 packets lost: 373
+connection 0 second 1 send window: 1238055 packets sent: 377515 packets lost: 123
+connection 0 second 2 send window: 583352 packets sent: 355482 packets lost: 862
+connection 0 second 3 send window: 275563 packets sent: 367538 packets lost: 607
+connection 0 second 4 send window: 1100261 packets sent: 366005 packets lost: 20
+connection 0 second 5 send window: 633010 packets sent: 356021 packets lost: 857
+connection 0 second 6 send window: 1266610 packets sent: 367866 packets lost: 0
+connection 0 second 7 send window: 1668530 packets sent: 360649 packets lost: 0
+connection 0 second 8 send window: 1994930 packets sent: 364087 packets lost: 0
+connection 0 second 9 send window: 1779683 packets sent: 374804 packets lost: 80
+connection 0 total packets sent: 3654759 total packets lost: 2922
 ```
 *Note*: The server looks for a TLS certificate and key in the current working dir named "server.crt" and "server.key" respectively. You can use a self signed certificate; the client doesn't validate it.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Uses https://github.com/h2o/quicly
 Usage: ./qperf [options]
 
 Options:
+  -p              port to listen on/connect to (default 18080)
   -s              run as server
   -c target       run as client and connect to target server
   -t time (s)     run for X seconds (default 10s)

--- a/client.c
+++ b/client.c
@@ -119,9 +119,9 @@ static void client_on_conn_close(quicly_closed_by_peer_t *self, quicly_conn_t *c
 static quicly_stream_open_t stream_open = {&client_on_stream_open};
 static quicly_closed_by_peer_t closed_by_peer = {&client_on_conn_close};
 
-int run_client(const char *host, int runtime_s, bool ttfb_only)
+int run_client(const char *port, const char *host, int runtime_s, bool ttfb_only)
 {
-    printf("running client with host=%s and runtime=%is\n", host, runtime_s);
+    printf("running client with host=%s, port=%s and runtime=%is\n", host, port, runtime_s);
     quit_after_first_byte = ttfb_only;
 
     client_ctx = quicly_spec_context;
@@ -139,7 +139,7 @@ int run_client(const char *host, int runtime_s, bool ttfb_only)
 
     struct sockaddr_storage sas;
     socklen_t salen;
-    if(resolve_address((void*)&sas, &salen, host, "18080", AF_INET, SOCK_DGRAM, IPPROTO_UDP) != 0) {
+    if(resolve_address((void*)&sas, &salen, host, port, AF_INET, SOCK_DGRAM, IPPROTO_UDP) != 0) {
         exit(-1);
     }
 

--- a/client.h
+++ b/client.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-int run_client(const char *host, int runtime_s, bool ttfb_only);
+int run_client(const char* port, const char *host, int runtime_s, bool ttfb_only);
 void quit_client();
 void quit_client();
 

--- a/client.h
+++ b/client.h
@@ -3,8 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-int run_client(const char* port, const char *host, int runtime_s, bool ttfb_only);
-void quit_client();
+int run_client(const char* port, bool gso, const char *host, int runtime_s, bool ttfb_only);
 void quit_client();
 
 void on_first_byte();

--- a/common.c
+++ b/common.c
@@ -7,6 +7,12 @@
 #include <picotls/openssl.h>
 #include <errno.h>
 
+#ifdef __linux__
+    /* UDP GSO is only supported on linux */
+    #ifndef UDP_SEGMENT
+        #define UDP_SEGMENT 103 /* Set GSO segmentation size */
+    #endif
+#endif
 
 ptls_context_t *get_tlsctx()
 {
@@ -35,12 +41,6 @@ struct addrinfo *get_address(const char *host, const char *port)
         return result;
     }
 }
-
-#ifdef __linux__
-    #ifndef UDP_SEGMENT
-        #define UDP_SEGMENT 103
-    #endif
-#endif
 
 bool send_dgrams_default(int fd, struct sockaddr *dest, struct iovec *dgrams, size_t num_dgrams)
 {

--- a/common.c
+++ b/common.c
@@ -7,13 +7,6 @@
 #include <picotls/openssl.h>
 #include <errno.h>
 
-#ifdef __linux__
-    /* UDP GSO is only supported on linux */
-    #ifndef UDP_SEGMENT
-        #define UDP_SEGMENT 103 /* Set GSO segmentation size */
-    #endif
-#endif
-
 ptls_context_t *get_tlsctx()
 {
     static ptls_context_t tlsctx = {.random_bytes = ptls_openssl_random_bytes,
@@ -62,6 +55,12 @@ bool send_dgrams_default(int fd, struct sockaddr *dest, struct iovec *dgrams, si
     return true;
 }
 
+#ifdef __linux__
+    /* UDP GSO is only supported on linux */
+    #ifndef UDP_SEGMENT
+        #define UDP_SEGMENT 103 /* Set GSO segmentation size */
+    #endif
+
 bool send_dgrams_gso(int fd, struct sockaddr *dest, struct iovec *dgrams, size_t num_dgrams)
 {
     struct iovec vec = {
@@ -98,6 +97,8 @@ bool send_dgrams_gso(int fd, struct sockaddr *dest, struct iovec *dgrams, size_t
 
     return true;
 }
+
+#endif
 
 bool (*send_dgrams)(int fd, struct sockaddr *dest, struct iovec *dgrams, size_t num_dgrams) = send_dgrams_default;
 

--- a/common.h
+++ b/common.h
@@ -7,6 +7,7 @@
 ptls_context_t *get_tlsctx();
 
 struct addrinfo *get_address(const char *host, const char *port);
+void enable_gso();
 bool send_pending(quicly_context_t *ctx, int fd, quicly_conn_t *conn);
 void print_escaped(const char *src, size_t len);
 

--- a/common.h
+++ b/common.h
@@ -3,6 +3,8 @@
 #include <quicly.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <unistd.h>
+#include <sys/syscall.h>
 
 ptls_context_t *get_tlsctx();
 
@@ -38,4 +40,17 @@ static inline int64_t clamp_int64(int64_t val, int64_t min, int64_t max)
         return max;
     }
     return val;
+}
+
+static inline uint64_t get_current_pid()
+{
+    uint64_t pid;
+
+    #ifdef __APPLE__
+        pthread_threadid_np(NULL, &pid);
+    #else
+        pid = syscall(SYS_gettid);
+    #endif
+
+    return pid;
 }

--- a/main.c
+++ b/main.c
@@ -35,40 +35,40 @@ int main(int argc, char** argv)
 
     while ((ch = getopt(argc, argv, "c:egp:st:h")) != -1) {
         switch (ch) {
-            case 'c':
-                host = optarg;
-                break;
-            case 'e':
-                ttfb_only = true;
-                break;
-            case 'g':
-                #ifdef __linux__
-                    gso = true;
-                    printf("using UDP GSO, requires kernel >= 4.18\n");
-                #else
-                    fprintf(stderr, "UDP GSO only supported on linux\n");
-                    exit(1);
-                #endif
-                break;
-            case 'p':
-                port = (intptr_t)optarg;
-                if(sscanf(optarg, "%u", &port) < 0 || port > 65535) {
-                    fprintf(stderr, "invalid argument passed to -p\n");
-                    exit(1);
-                }
-                break;
-            case 's':
-                server_mode = true;
-                break;
-            case 't':
-                if(sscanf(optarg, "%u", &runtime_s) != 1 || runtime_s < 1) {
-                    fprintf(stderr, "invalid argument passed to -t\n");
-                    exit(1);
-                }
-                break;
-            default:
-                usage(argv[0]);
+        case 'c':
+            host = optarg;
+            break;
+        case 'e':
+            ttfb_only = true;
+            break;
+        case 'g':
+            #ifdef __linux__
+                gso = true;
+                printf("using UDP GSO, requires kernel >= 4.18\n");
+            #else
+                fprintf(stderr, "UDP GSO only supported on linux\n");
                 exit(1);
+            #endif
+            break;
+        case 'p':
+            port = (intptr_t)optarg;
+            if(sscanf(optarg, "%u", &port) < 0 || port > 65535) {
+                fprintf(stderr, "invalid argument passed to -p\n");
+                exit(1);
+            }
+            break;
+        case 's':
+            server_mode = true;
+            break;
+        case 't':
+            if(sscanf(optarg, "%u", &runtime_s) != 1 || runtime_s < 1) {
+                fprintf(stderr, "invalid argument passed to -t\n");
+                exit(1);
+            }
+            break;
+        default:
+            usage(argv[0]);
+            exit(1);
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -10,15 +10,16 @@
 static void usage(const char *cmd)
 {
     printf("Usage: %s [options]\n"
-           "\n"
-           "Options:\n"
-           "  -p              port to listen on/connect to (default 18080)\n"
-           "  -s              run as server\n"
-           "  -c target       run as client and connect to target server\n"
-           "  -t time (s)     run for X seconds (default 10s)\n"
-           "  -e              measure time for connection establishment and first byte only\n"
-           "  -h              print this help\n"
-           "\n",
+            "\n"
+            "Options:\n"
+            "  -c target       run as client and connect to target server\n"
+            "  -e              measure time for connection establishment and first byte only\n"
+            "  -g              enable UDP generic segmentation offload\n"
+            "  -p              port to listen on/connect to (default 18080)\n"
+            "  -s              run as server\n"
+            "  -t time (s)     run for X seconds (default 10s)\n"
+            "  -h              print this help\n"
+            "\n",
            cmd);
 }
 
@@ -30,34 +31,44 @@ int main(int argc, char** argv)
     int runtime_s = 10;
     int ch;
     bool ttfb_only = false;
+    bool gso = false;
 
-    while ((ch = getopt(argc, argv, "p:sc:t:he")) != -1) {
+    while ((ch = getopt(argc, argv, "c:egp:st:h")) != -1) {
         switch (ch) {
-        case 'p':
-            port = optarg;
-            if(sscanf(optarg, "%u", &port) < 0 || port > 65535) {
-                fprintf(stderr, "invalid argument passed to -p\n");
+            case 'c':
+                host = optarg;
+                break;
+            case 'e':
+                ttfb_only = true;
+                break;
+            case 'g':
+                #ifdef __linux__
+                    gso = true;
+                    printf("using UDP GSO, requires enabled 'generic-segmentation-offload' and kernel >= 4.18\n");
+                #else
+                    fprintf(stderr, "UDP GSO only supported on linux\n");
+                    exit(1);
+                #endif
+                break;
+            case 'p':
+                port = (intptr_t)optarg;
+                if(sscanf(optarg, "%u", &port) < 0 || port > 65535) {
+                    fprintf(stderr, "invalid argument passed to -p\n");
+                    exit(1);
+                }
+                break;
+            case 's':
+                server_mode = true;
+                break;
+            case 't':
+                if(sscanf(optarg, "%u", &runtime_s) != 1 || runtime_s < 1) {
+                    fprintf(stderr, "invalid argument passed to -t\n");
+                    exit(1);
+                }
+                break;
+            default:
+                usage(argv[0]);
                 exit(1);
-            }
-            break;
-        case 's':
-            server_mode = true;
-            break;
-        case 'c':
-            host = optarg;
-            break;
-        case 't':
-            if(sscanf(optarg, "%u", &runtime_s) != 1 || runtime_s < 1) {
-                fprintf(stderr, "invalid argument passed to -t\n");
-                exit(1);
-            }
-            break;
-        case 'e':
-            ttfb_only = true;
-            break;
-        default:
-            usage(argv[0]);
-            exit(1);
         }
     }
 

--- a/main.c
+++ b/main.c
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
             case 'g':
                 #ifdef __linux__
                     gso = true;
-                    printf("using UDP GSO, requires enabled 'generic-segmentation-offload' and kernel >= 4.18\n");
+                    printf("using UDP GSO, requires kernel >= 4.18\n");
                 #else
                     fprintf(stderr, "UDP GSO only supported on linux\n");
                     exit(1);

--- a/main.c
+++ b/main.c
@@ -12,6 +12,7 @@ static void usage(const char *cmd)
     printf("Usage: %s [options]\n"
            "\n"
            "Options:\n"
+           "  -p              port to listen on/connect to (default 18080)\n"
            "  -s              run as server\n"
            "  -c target       run as client and connect to target server\n"
            "  -t time (s)     run for X seconds (default 10s)\n"
@@ -23,14 +24,22 @@ static void usage(const char *cmd)
 
 int main(int argc, char** argv)
 {
+    int port = 18080;
     bool server_mode = false;
     const char *host = NULL;
     int runtime_s = 10;
     int ch;
     bool ttfb_only = false;
 
-    while ((ch = getopt(argc, argv, "sc:t:he")) != -1) {
+    while ((ch = getopt(argc, argv, "p:sc:t:he")) != -1) {
         switch (ch) {
+        case 'p':
+            port = optarg;
+            if(sscanf(optarg, "%u", &port) < 0 || port > 65535) {
+                fprintf(stderr, "invalid argument passed to -p\n");
+                exit(1);
+            }
+            break;
         case 's':
             server_mode = true;
             break;
@@ -62,7 +71,9 @@ int main(int argc, char** argv)
         exit(1);
     }
 
+    char port_char[16];
+    sprintf(port_char, "%d", port);
     return server_mode ?
-                run_server("server.crt", "server.key") :
-                run_client(host, runtime_s, ttfb_only);
+                run_server(port_char, "server.crt", "server.key") :
+                run_client(port_char, host, runtime_s, ttfb_only);
 }

--- a/main.c
+++ b/main.c
@@ -85,6 +85,6 @@ int main(int argc, char** argv)
     char port_char[16];
     sprintf(port_char, "%d", port);
     return server_mode ?
-                run_server(port_char, "server.crt", "server.key") :
-                run_client(port_char, host, runtime_s, ttfb_only);
+                run_server(port_char, gso, "server.crt", "server.key") :
+                run_client(port_char, gso, host, runtime_s, ttfb_only);
 }

--- a/server.c
+++ b/server.c
@@ -10,7 +10,6 @@
 #include <float.h>
 #include <inttypes.h>
 #include <stdbool.h>
-#include <sys/syscall.h> 
 
 #include <quicly/streambuf.h>
 
@@ -206,16 +205,8 @@ int run_server(const char *port, bool gso, const char *cert, const char *key)
         return 1;
     }
 
-    uint64_t pid;
-
-    #ifdef __APPLE__
-        pthread_threadid_np(NULL, &pid);
-    #else
-        pid = syscall(SYS_gettid);
-    #endif
-
     char pid_char[21];
-    sprintf(pid_char, "%" PRIu64, pid);
+    sprintf(pid_char, "%" PRIu64, get_current_pid());
 
     printf("starting server with pid %s on port %s\n", pid_char, port);
 

--- a/server.c
+++ b/server.c
@@ -205,10 +205,7 @@ int run_server(const char *port, bool gso, const char *cert, const char *key)
         return 1;
     }
 
-    char pid_char[21];
-    sprintf(pid_char, "%" PRIu64, get_current_pid());
-
-    printf("starting server with pid %s on port %s\n", pid_char, port);
+    printf("starting server with pid %" PRIu64 " on port %s\n", get_current_pid(), port);
 
     ev_io socket_watcher;
     ev_io_init(&socket_watcher, &server_read_cb, server_socket, EV_READ);

--- a/server.c
+++ b/server.c
@@ -10,6 +10,7 @@
 #include <float.h>
 #include <inttypes.h>
 #include <stdbool.h>
+#include <sys/syscall.h> 
 
 #include <quicly/streambuf.h>
 
@@ -201,7 +202,18 @@ int run_server(const char *port, const char *cert, const char *key)
         return 1;
     }
 
-    printf("starting server on port %s\n", port);
+    uint64_t pid;
+
+    #ifdef __APPLE__
+        pthread_threadid_np(NULL, &pid);
+    #else
+        pid = syscall(SYS_gettid);
+    #endif
+
+    char pid_char[21];
+    sprintf(pid_char, "%" PRIu64, pid);
+
+    printf("starting server with pid %s on port %s\n", pid_char, port);
 
     ev_io socket_watcher;
     ev_io_init(&socket_watcher, &server_read_cb, server_socket, EV_READ);

--- a/server.c
+++ b/server.c
@@ -170,7 +170,7 @@ static void server_on_conn_close(quicly_closed_by_peer_t *self, quicly_conn_t *c
 static quicly_stream_open_t stream_open = {&server_on_stream_open};
 static quicly_closed_by_peer_t closed_by_peer = {&server_on_conn_close};
 
-int run_server(const char *cert, const char *key)
+int run_server(const char *port, const char *cert, const char *key)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());
@@ -188,20 +188,20 @@ int run_server(const char *cert, const char *key)
 
     struct ev_loop *loop = EV_DEFAULT;
 
-    struct addrinfo *addr = get_address("0.0.0.0", "18080");
+    struct addrinfo *addr = get_address("0.0.0.0", port);
     if(addr == NULL) {
-        perror("failed get addrinfo for port 18080");
+        printf("failed get addrinfo for port %s\n", port);
         return -1;
     }
 
     server_socket = udp_listen(addr);
     freeaddrinfo(addr);
     if(server_socket == -1) {
-        perror("failed to listen on port 18080");
+        printf("failed to listen on port %s\n", port);
         return 1;
     }
 
-    printf("starting server on port 18080\n");
+    printf("starting server on port %s\n", port);
 
     ev_io socket_watcher;
     ev_io_init(&socket_watcher, &server_read_cb, server_socket, EV_READ);

--- a/server.h
+++ b/server.h
@@ -3,5 +3,5 @@
 #include <quicly.h>
 #include <stdbool.h>
 
-int run_server(const char* port, const char *cert, const char *key);
+int run_server(const char* port, bool gso, const char *cert, const char *key);
 

--- a/server.h
+++ b/server.h
@@ -3,5 +3,5 @@
 #include <quicly.h>
 #include <stdbool.h>
 
-int run_server(const char *cert, const char *key);
+int run_server(const char* port, const char *cert, const char *key);
 


### PR DESCRIPTION
Add support for UDP generic segmentation offload, which was added to quicly in 03/2020: https://github.com/h2o/quicly/pull/293

GSO is enabled by `-g` cli option and requires linux kernel >= 4.18.

Perf eval shows less cpu cylces spent in `sendmsg` while using GSO (~70% to ~48%). Running on a loopback interface, transfer rates increase from ~3gbps to ~5gbps.

Emulating a 1gbps link between docker containers, measurements without GSO show CPU utilization ~100% and goodput topping at ~810mbps. Enabling GSO, CPU utilization drops to ~66%, goodput increases to ~920mbps.