### PR TITLE
Add TLS secret logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.user
 *.vscode
-build/
+build*

--- a/client.c
+++ b/client.c
@@ -121,8 +121,8 @@ static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
 
 int run_client(const char *port, bool gso, const char *host, int runtime_s, bool ttfb_only)
 {
-    printf("running client with host=%s, port=%s and runtime=%is\n", host, port, runtime_s);
-    quit_after_first_byte = ttfb_only;
+    setup_session_cache(get_tlsctx());
+    quicly_amend_ptls_context(get_tlsctx());
 
     client_ctx = quicly_spec_context;
     client_ctx.tls = get_tlsctx();
@@ -135,9 +135,6 @@ int run_client(const char *port, bool gso, const char *host, int runtime_s, bool
     if (gso) {
         enable_gso();
     }
-
-    setup_session_cache(get_tlsctx());
-    quicly_amend_ptls_context(get_tlsctx());
 
     struct ev_loop *loop = EV_DEFAULT;
 
@@ -161,6 +158,9 @@ int run_client(const char *port, bool gso, const char *host, int runtime_s, bool
         perror("bind(2) failed");
         return 1;
     }
+
+    printf("running client with host=%s, port=%s and runtime=%is\n", host, port, runtime_s);
+    quit_after_first_byte = ttfb_only;
 
     // start time
     start_time = client_ctx.now->cb(client_ctx.now);

--- a/client.c
+++ b/client.c
@@ -119,7 +119,7 @@ static void client_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 static quicly_stream_open_t stream_open = {&client_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
 
-int run_client(const char *port, bool gso, const char *host, int runtime_s, bool ttfb_only)
+int run_client(const char *port, bool gso, const char *logfile, const char *host, int runtime_s, bool ttfb_only)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());
@@ -157,6 +157,11 @@ int run_client(const char *port, bool gso, const char *host, int runtime_s, bool
     if (bind(client_socket, (void *)&local, sizeof(local)) != 0) {
         perror("bind(2) failed");
         return 1;
+    }
+
+    if (logfile)
+    {
+        setup_log_event(client_ctx.tls, logfile);
     }
 
     printf("running client with host=%s, port=%s and runtime=%is\n", host, port, runtime_s);

--- a/client.h
+++ b/client.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-int run_client(const char* port, bool gso, const char *host, int runtime_s, bool ttfb_only);
+int run_client(const char* port, bool gso, const char *logfile, const char *host, int runtime_s, bool ttfb_only);
 void quit_client();
 
 void on_first_byte();

--- a/main.c
+++ b/main.c
@@ -15,6 +15,7 @@ static void usage(const char *cmd)
             "  -c target       run as client and connect to target server\n"
             "  -e              measure time for connection establishment and first byte only\n"
             "  -g              enable UDP generic segmentation offload\n"
+            "  -l log-file     file to log tls secrets\n"
             "  -p              port to listen on/connect to (default 18080)\n"
             "  -s              run as server\n"
             "  -t time (s)     run for X seconds (default 10s)\n"
@@ -34,7 +35,7 @@ int main(int argc, char** argv)
     bool gso = false;
     const char *logfile = NULL;
 
-    while ((ch = getopt(argc, argv, "c:egp:st:h")) != -1) {
+    while ((ch = getopt(argc, argv, "c:egl:p:st:h")) != -1) {
         switch (ch) {
         case 'c':
             host = optarg;
@@ -50,6 +51,9 @@ int main(int argc, char** argv)
                 fprintf(stderr, "UDP GSO only supported on linux\n");
                 exit(1);
             #endif
+            break;
+        case 'l':
+            logfile = optarg;
             break;
         case 'p':
             port = (intptr_t)optarg;

--- a/main.c
+++ b/main.c
@@ -32,6 +32,7 @@ int main(int argc, char** argv)
     int ch;
     bool ttfb_only = false;
     bool gso = false;
+    const char *logfile = NULL;
 
     while ((ch = getopt(argc, argv, "c:egp:st:h")) != -1) {
         switch (ch) {
@@ -85,6 +86,6 @@ int main(int argc, char** argv)
     char port_char[16];
     sprintf(port_char, "%d", port);
     return server_mode ?
-                run_server(port_char, gso, "server.crt", "server.key") :
-                run_client(port_char, gso, host, runtime_s, ttfb_only);
+                run_server(port_char, gso, logfile, "server.crt", "server.key") :
+                run_client(port_char, gso, logfile, host, runtime_s, ttfb_only);
 }

--- a/server.c
+++ b/server.c
@@ -170,7 +170,7 @@ static void server_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 static quicly_stream_open_t stream_open = {&server_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&server_on_conn_close};
 
-int run_server(const char *port, bool gso, const char *cert, const char *key)
+int run_server(const char *port, bool gso, const char *logfile, const char *cert, const char *key)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());
@@ -203,6 +203,11 @@ int run_server(const char *port, bool gso, const char *cert, const char *key)
     if(server_socket == -1) {
         printf("failed to listen on port %s\n", port);
         return 1;
+    }
+
+    if (logfile)
+    {
+        setup_log_event(server_ctx.tls, logfile);
     }
 
     printf("starting server with pid %" PRIu64 " on port %s\n", get_current_pid(), port);

--- a/server.h
+++ b/server.h
@@ -3,5 +3,5 @@
 #include <quicly.h>
 #include <stdbool.h>
 
-int run_server(const char* port, bool gso, const char *cert, const char *key);
+int run_server(const char* port, bool gso, const char *logfile, const char *cert, const char *key);
 


### PR DESCRIPTION
Add support for TLS secret logging, which was added to quicly in 03/2019: https://github.com/h2o/quicly/pull/102

Logging is enabled by `-l` cli option stating the desired output file. File can be used by Wireshark (i.e., `Edit -> Preferences -> Protocols -> TLS -> (Pre)-Master-Secret log filename`) to decrypt captured traffic.