### PR TITLE
Add congestion control and iw options

### DIFF
--- a/client.c
+++ b/client.c
@@ -118,6 +118,8 @@ static void client_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 
 static quicly_stream_open_t stream_open = {&client_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
+static quicly_init_cc_t client_init_cc_reno = {&init_cc_reno};
+static quicly_init_cc_t client_init_cc_cubic = {&init_cc_cubic};
 
 int run_client(const char *port, bool gso, const char *logfile, const char *cc, const char *host, int runtime_s, bool ttfb_only)
 {
@@ -131,6 +133,12 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
     client_ctx.transport_params.max_stream_data.uni = UINT32_MAX;
     client_ctx.transport_params.max_stream_data.bidi_local = UINT32_MAX;
     client_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
+
+    if(strcmp(cc, "reno") == 0) {
+        client_ctx.init_cc = &client_init_cc_reno;
+    } else if(strcmp(cc, "cubic") == 0) {
+        client_ctx.init_cc = &client_init_cc_cubic;
+    }
 
     if (gso) {
         enable_gso();

--- a/client.c
+++ b/client.c
@@ -172,7 +172,7 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
         setup_log_event(client_ctx.tls, logfile);
     }
 
-    printf("running client with host=%s, port=%s and runtime=%is\n", host, port, runtime_s);
+    printf("starting client with host %s, port %s, runtime %is, cc %s\n", host, port, runtime_s, cc);
     quit_after_first_byte = ttfb_only;
 
     // start time

--- a/client.c
+++ b/client.c
@@ -121,7 +121,7 @@ static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
 static quicly_init_cc_t client_init_cc_reno = {&init_cc_reno};
 static quicly_init_cc_t client_init_cc_cubic = {&init_cc_cubic};
 
-int run_client(const char *port, bool gso, const char *logfile, const char *cc, const char *host, int runtime_s, bool ttfb_only)
+int run_client(const char *port, bool gso, const char *logfile, const char *cc, int iw, const char *host, int runtime_s, bool ttfb_only)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());

--- a/client.c
+++ b/client.c
@@ -140,6 +140,8 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
         client_ctx.init_cc = &client_init_cc_cubic;
     }
 
+    set_iw(iw, client_ctx.transport_params.max_udp_payload_size);
+
     if (gso) {
         enable_gso();
     }

--- a/client.c
+++ b/client.c
@@ -174,7 +174,7 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
         setup_log_event(client_ctx.tls, logfile);
     }
 
-    printf("starting client with host %s, port %s, runtime %is, cc %s\n", host, port, runtime_s, cc);
+    printf("starting client with host %s, port %s, runtime %is, cc %s, iw %i\n", host, port, runtime_s, cc, iw);
     quit_after_first_byte = ttfb_only;
 
     // start time

--- a/client.c
+++ b/client.c
@@ -119,7 +119,7 @@ static void client_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 static quicly_stream_open_t stream_open = {&client_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
 
-int run_client(const char *port, bool gso, const char *logfile, const char *host, int runtime_s, bool ttfb_only)
+int run_client(const char *port, bool gso, const char *logfile, const char *cc, const char *host, int runtime_s, bool ttfb_only)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());

--- a/client.h
+++ b/client.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-int run_client(const char* port, bool gso, const char *logfile, const char *cc, const char *host, int runtime_s, bool ttfb_only);
+int run_client(const char* port, bool gso, const char *logfile, const char *cc, int iw, const char *host, int runtime_s, bool ttfb_only);
 void quit_client();
 
 void on_first_byte();

--- a/client.h
+++ b/client.h
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-int run_client(const char* port, bool gso, const char *logfile, const char *host, int runtime_s, bool ttfb_only);
+int run_client(const char* port, bool gso, const char *logfile, const char *cc, const char *host, int runtime_s, bool ttfb_only);
 void quit_client();
 
 void on_first_byte();

--- a/common.h
+++ b/common.h
@@ -6,6 +6,8 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
+uint32_t iw_cc;
+
 ptls_context_t *get_tlsctx();
 
 struct addrinfo *get_address(const char *host, const char *port);
@@ -57,10 +59,15 @@ static inline uint64_t get_current_pid()
 
 static void init_cc_reno(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
-    quicly_cc_reno_init(cc, initcwnd);
+    quicly_cc_reno_init(cc, iw_cc);
 }
 
 static void init_cc_cubic(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
 {
-    quicly_cc_cubic_init(cc, initcwnd);
+    quicly_cc_cubic_init(cc, iw_cc);
+}
+
+static void set_iw(int iw, uint64_t max_udp_payload_size)
+{
+    iw_cc = iw * max_udp_payload_size;
 }

--- a/common.h
+++ b/common.h
@@ -54,3 +54,13 @@ static inline uint64_t get_current_pid()
 
     return pid;
 }
+
+static void init_cc_reno(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+{
+    quicly_cc_reno_init(cc, initcwnd);
+}
+
+static void init_cc_cubic(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
+{
+    quicly_cc_cubic_init(cc, initcwnd);
+}

--- a/main.c
+++ b/main.c
@@ -105,6 +105,6 @@ int main(int argc, char** argv)
     char port_char[16];
     sprintf(port_char, "%d", port);
     return server_mode ?
-                run_server(port_char, gso, logfile, "server.crt", "server.key") :
-                run_client(port_char, gso, logfile, host, runtime_s, ttfb_only);
+                run_server(port_char, gso, logfile, cc, "server.crt", "server.key") :
+                run_client(port_char, gso, logfile, cc, host, runtime_s, ttfb_only);
 }

--- a/main.c
+++ b/main.c
@@ -12,17 +12,24 @@ static void usage(const char *cmd)
     printf("Usage: %s [options]\n"
             "\n"
             "Options:\n"
-            "  -c target       run as client and connect to target server\n"
-            "  -e              measure time for connection establishment and first byte only\n"
-            "  -g              enable UDP generic segmentation offload\n"
-            "  -l log-file     file to log tls secrets\n"
-            "  -p              port to listen on/connect to (default 18080)\n"
-            "  -s              run as server\n"
-            "  -t time (s)     run for X seconds (default 10s)\n"
-            "  -h              print this help\n"
+            "  -c target           run as client and connect to target server\n"
+            "  --cc [reno,cubic]   congestion control algorithm to use (default reno)\n"
+            "  -e                  measure time for connection establishment and first byte only\n"
+            "  -g                  enable UDP generic segmentation offload\n"
+            "  -l log-file         file to log tls secrets\n"
+            "  -p                  port to listen on/connect to (default 18080)\n"
+            "  -s                  run as server\n"
+            "  -t time (s)         run for X seconds (default 10s)\n"
+            "  -h                  print this help\n"
             "\n",
            cmd);
 }
+
+static struct option long_options[] = 
+{
+    {"cc", required_argument, NULL, 0},
+    {NULL, 0, NULL, 0}
+};
 
 int main(int argc, char** argv)
 {
@@ -34,9 +41,17 @@ int main(int argc, char** argv)
     bool ttfb_only = false;
     bool gso = false;
     const char *logfile = NULL;
+    const char *cc = "reno";
 
-    while ((ch = getopt(argc, argv, "c:egl:p:st:h")) != -1) {
+    while ((ch = getopt_long(argc, argv, "c:egl:p:st:h", long_options, NULL)) != -1) {
         switch (ch) {
+        case 0:
+            if(strcmp(optarg, "reno") != 0 && strcmp(optarg, "cubic") != 0) {
+                fprintf(stderr, "invalid argument passed to --cc\n");
+                exit(1);
+            }
+            cc = optarg;
+            break;
         case 'c':
             host = optarg;
             break;

--- a/main.c
+++ b/main.c
@@ -42,6 +42,7 @@ int main(int argc, char** argv)
     bool gso = false;
     const char *logfile = NULL;
     const char *cc = "reno";
+    int iw = 10;
 
     while ((ch = getopt_long(argc, argv, "c:egl:p:st:h", long_options, NULL)) != -1) {
         switch (ch) {
@@ -105,6 +106,6 @@ int main(int argc, char** argv)
     char port_char[16];
     sprintf(port_char, "%d", port);
     return server_mode ?
-                run_server(port_char, gso, logfile, cc, "server.crt", "server.key") :
-                run_client(port_char, gso, logfile, cc, host, runtime_s, ttfb_only);
+                run_server(port_char, gso, logfile, cc, iw, "server.crt", "server.key") :
+                run_client(port_char, gso, logfile, cc, iw, host, runtime_s, ttfb_only);
 }

--- a/main.c
+++ b/main.c
@@ -12,15 +12,16 @@ static void usage(const char *cmd)
     printf("Usage: %s [options]\n"
             "\n"
             "Options:\n"
-            "  -c target           run as client and connect to target server\n"
-            "  --cc [reno,cubic]   congestion control algorithm to use (default reno)\n"
-            "  -e                  measure time for connection establishment and first byte only\n"
-            "  -g                  enable UDP generic segmentation offload\n"
-            "  -l log-file         file to log tls secrets\n"
-            "  -p                  port to listen on/connect to (default 18080)\n"
-            "  -s                  run as server\n"
-            "  -t time (s)         run for X seconds (default 10s)\n"
-            "  -h                  print this help\n"
+            "  -c target            run as client and connect to target server\n"
+            "  --cc [reno,cubic]    congestion control algorithm to use (default reno)\n"
+            "  -e                   measure time for connection establishment and first byte only\n"
+            "  -g                   enable UDP generic segmentation offload\n"
+            "  --iw initial-window  initial window to use (default 10)\n"
+            "  -l log-file          file to log tls secrets\n"
+            "  -p                   port to listen on/connect to (default 18080)\n"
+            "  -s                   run as server\n"
+            "  -t time (s)          run for X seconds (default 10s)\n"
+            "  -h                   print this help\n"
             "\n",
            cmd);
 }
@@ -28,6 +29,7 @@ static void usage(const char *cmd)
 static struct option long_options[] = 
 {
     {"cc", required_argument, NULL, 0},
+    {"iw", required_argument, NULL, 1},
     {NULL, 0, NULL, 0}
 };
 
@@ -52,6 +54,13 @@ int main(int argc, char** argv)
                 exit(1);
             }
             cc = optarg;
+            break;
+        case 1:
+            iw = (intptr_t)optarg;
+            if(sscanf(optarg, "%u", &iw) < 0 || iw < 1) {
+                fprintf(stderr, "invalid argument passed to --iw\n");
+                exit(1);
+            }
             break;
         case 'c':
             host = optarg;

--- a/server.c
+++ b/server.c
@@ -220,7 +220,7 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
         setup_log_event(server_ctx.tls, logfile);
     }
 
-    printf("starting server with pid %" PRIu64 ", port %s, cc %s\n", get_current_pid(), port, cc);
+    printf("starting server with pid %" PRIu64 ", port %s, cc %s, iw %i\n", get_current_pid(), port, cc, iw);
 
     ev_io socket_watcher;
     ev_io_init(&socket_watcher, &server_read_cb, server_socket, EV_READ);

--- a/server.c
+++ b/server.c
@@ -170,7 +170,7 @@ static void server_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 static quicly_stream_open_t stream_open = {&server_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&server_on_conn_close};
 
-int run_server(const char *port, bool gso, const char *logfile, const char *cert, const char *key)
+int run_server(const char *port, bool gso, const char *logfile, const char *cc, const char *cert, const char *key)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());

--- a/server.c
+++ b/server.c
@@ -169,6 +169,8 @@ static void server_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 
 static quicly_stream_open_t stream_open = {&server_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&server_on_conn_close};
+static quicly_init_cc_t server_init_cc_reno = {&init_cc_reno};
+static quicly_init_cc_t server_init_cc_cubic = {&init_cc_cubic};
 
 int run_server(const char *port, bool gso, const char *logfile, const char *cc, const char *cert, const char *key)
 {
@@ -183,6 +185,12 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
     server_ctx.transport_params.max_stream_data.bidi_local = UINT32_MAX;
     server_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
 
+    if(strcmp(cc, "reno") == 0) {
+        server_ctx.init_cc = &server_init_cc_reno;
+    } else if(strcmp(cc, "cubic") == 0) {
+        server_ctx.init_cc = &server_init_cc_cubic;
+    }
+    
     if (gso) {
         enable_gso();
     }

--- a/server.c
+++ b/server.c
@@ -218,7 +218,7 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
         setup_log_event(server_ctx.tls, logfile);
     }
 
-    printf("starting server with pid %" PRIu64 " on port %s\n", get_current_pid(), port);
+    printf("starting server with pid %" PRIu64 ", port %s, cc %s\n", get_current_pid(), port, cc);
 
     ev_io socket_watcher;
     ev_io_init(&socket_watcher, &server_read_cb, server_socket, EV_READ);

--- a/server.c
+++ b/server.c
@@ -190,6 +190,8 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
     } else if(strcmp(cc, "cubic") == 0) {
         server_ctx.init_cc = &server_init_cc_cubic;
     }
+
+    set_iw(iw, server_ctx.transport_params.max_udp_payload_size);
     
     if (gso) {
         enable_gso();

--- a/server.c
+++ b/server.c
@@ -172,7 +172,7 @@ static quicly_closed_by_remote_t closed_by_remote = {&server_on_conn_close};
 static quicly_init_cc_t server_init_cc_reno = {&init_cc_reno};
 static quicly_init_cc_t server_init_cc_cubic = {&init_cc_cubic};
 
-int run_server(const char *port, bool gso, const char *logfile, const char *cc, const char *cert, const char *key)
+int run_server(const char *port, bool gso, const char *logfile, const char *cc, int iw, const char *cert, const char *key)
 {
     setup_session_cache(get_tlsctx());
     quicly_amend_ptls_context(get_tlsctx());

--- a/server.h
+++ b/server.h
@@ -3,5 +3,5 @@
 #include <quicly.h>
 #include <stdbool.h>
 
-int run_server(const char* port, bool gso, const char *logfile, const char *cert, const char *key);
+int run_server(const char* port, bool gso, const char *logfile, const char *cc, const char *cert, const char *key);
 

--- a/server.h
+++ b/server.h
@@ -3,5 +3,5 @@
 #include <quicly.h>
 #include <stdbool.h>
 
-int run_server(const char* port, bool gso, const char *logfile, const char *cc, const char *cert, const char *key);
+int run_server(const char* port, bool gso, const char *logfile, const char *cc, int iw, const char *cert, const char *key);
 


### PR DESCRIPTION
Quicly [recently](https://github.com/h2o/quicly/issues/365) introduced `cubic` as alternative to `reno` congestion control algorithm. Additionally, the [callback handler](https://github.com/h2o/quicly/pull/370) to change the cca on a per-connection basis can be used to overwrite the default initial congestion window of [10 * max_udp_payload_size](https://github.com/h2o/quicly/blob/b53b69322b837bb79bec586afed4accc947def2d/lib/cc-reno.c#L93-L101).
This PR exposes the congestion control via `--cc`, and the initial window via `--iw`.