### PR TITLE
Update quicly to fix traffic secret labels

### DIFF
--- a/client.c
+++ b/client.c
@@ -118,8 +118,6 @@ static void client_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 
 static quicly_stream_open_t stream_open = {&client_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&client_on_conn_close};
-static quicly_init_cc_t client_init_cc_reno = {&init_cc_reno};
-static quicly_init_cc_t client_init_cc_cubic = {&init_cc_cubic};
 
 int run_client(const char *port, bool gso, const char *logfile, const char *cc, int iw, const char *host, int runtime_s, bool ttfb_only)
 {
@@ -135,9 +133,9 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
     client_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
 
     if(strcmp(cc, "reno") == 0) {
-        client_ctx.init_cc = &client_init_cc_reno;
+        client_ctx.init_cc = &quicly_cc_reno_init;
     } else if(strcmp(cc, "cubic") == 0) {
-        client_ctx.init_cc = &client_init_cc_cubic;
+        client_ctx.init_cc = &quicly_cc_cubic_init;
     }
 
     set_iw(iw, client_ctx.transport_params.max_udp_payload_size);

--- a/common.h
+++ b/common.h
@@ -57,16 +57,6 @@ static inline uint64_t get_current_pid()
     return pid;
 }
 
-static void init_cc_reno(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
-{
-    quicly_cc_reno_init(cc, iw_cc);
-}
-
-static void init_cc_cubic(quicly_init_cc_t *init_cc, quicly_cc_t *cc, uint32_t initcwnd, int64_t now)
-{
-    quicly_cc_cubic_init(cc, iw_cc);
-}
-
 static void set_iw(int iw, uint64_t max_udp_payload_size)
 {
     iw_cc = iw * max_udp_payload_size;

--- a/server.c
+++ b/server.c
@@ -169,8 +169,6 @@ static void server_on_conn_close(quicly_closed_by_remote_t *self, quicly_conn_t 
 
 static quicly_stream_open_t stream_open = {&server_on_stream_open};
 static quicly_closed_by_remote_t closed_by_remote = {&server_on_conn_close};
-static quicly_init_cc_t server_init_cc_reno = {&init_cc_reno};
-static quicly_init_cc_t server_init_cc_cubic = {&init_cc_cubic};
 
 int run_server(const char *port, bool gso, const char *logfile, const char *cc, int iw, const char *cert, const char *key)
 {
@@ -186,9 +184,9 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
     server_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
 
     if(strcmp(cc, "reno") == 0) {
-        server_ctx.init_cc = &server_init_cc_reno;
+        server_ctx.init_cc = &quicly_cc_reno_init;
     } else if(strcmp(cc, "cubic") == 0) {
-        server_ctx.init_cc = &server_init_cc_cubic;
+        server_ctx.init_cc = &quicly_cc_cubic_init;
     }
 
     set_iw(iw, server_ctx.transport_params.max_udp_payload_size);


### PR DESCRIPTION
Update quicly to recent master to incorporate [fix to traffic secret labels](https://github.com/h2o/quicly/pull/443), re-enabling Wireshark decryption using the logged tls secrets.

