### PR TITLE
Fix initcwnd config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ Uses https://github.com/h2o/quicly
 Usage: ./qperf [options]
 
 Options:
-  -c target       run as client and connect to target server
-  -e              measure time for connection establishment and first byte only
-  -g              enable UDP generic segmentation offload
-  -l log-file     file to log tls secrets
-  -p              port to listen on/connect to (default 18080)
-  -s              run as server
-  -t time (s)     run for X seconds (default 10s)
-  -h              print this help
+  -c target             run as client and connect to target server
+  --cc [reno,cubic]     congestion control algorithm to use (default reno)
+  -e                    measure time for connection establishment and first byte only
+  -g                    enable UDP generic segmentation offload
+  --iw initial-window   initial window to use (default 10)
+  -l log-file           file to log tls secrets
+  -p                    port to listen on/connect to (default 18080)
+  -s                    run as server
+  -t time (s)           run for X seconds (default 10s)
+  -h                    print this help
 ```
 
 server

--- a/client.c
+++ b/client.c
@@ -131,14 +131,13 @@ int run_client(const char *port, bool gso, const char *logfile, const char *cc, 
     client_ctx.transport_params.max_stream_data.uni = UINT32_MAX;
     client_ctx.transport_params.max_stream_data.bidi_local = UINT32_MAX;
     client_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
+    client_ctx.initcwnd_packets = iw;
 
     if(strcmp(cc, "reno") == 0) {
         client_ctx.init_cc = &quicly_cc_reno_init;
     } else if(strcmp(cc, "cubic") == 0) {
         client_ctx.init_cc = &quicly_cc_cubic_init;
     }
-
-    set_iw(iw, client_ctx.transport_params.max_udp_payload_size);
 
     if (gso) {
         enable_gso();

--- a/common.h
+++ b/common.h
@@ -6,8 +6,6 @@
 #include <unistd.h>
 #include <sys/syscall.h>
 
-uint32_t iw_cc;
-
 ptls_context_t *get_tlsctx();
 
 struct addrinfo *get_address(const char *host, const char *port);

--- a/common.h
+++ b/common.h
@@ -56,8 +56,3 @@ static inline uint64_t get_current_pid()
 
     return pid;
 }
-
-static void set_iw(int iw, uint64_t max_udp_payload_size)
-{
-    iw_cc = iw * max_udp_payload_size;
-}

--- a/main.c
+++ b/main.c
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
             break;
         case 1:
             iw = (intptr_t)optarg;
-            if(sscanf(optarg, "%u", &iw) < 0 || iw < 1) {
+            if (sscanf(optarg, "%" SCNu32, &iw) != 1) {
                 fprintf(stderr, "invalid argument passed to --iw\n");
                 exit(1);
             }

--- a/server.c
+++ b/server.c
@@ -182,6 +182,7 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
     server_ctx.transport_params.max_stream_data.uni = UINT32_MAX;
     server_ctx.transport_params.max_stream_data.bidi_local = UINT32_MAX;
     server_ctx.transport_params.max_stream_data.bidi_remote = UINT32_MAX;
+    server_ctx.initcwnd_packets = iw;
 
     if(strcmp(cc, "reno") == 0) {
         server_ctx.init_cc = &quicly_cc_reno_init;
@@ -189,8 +190,6 @@ int run_server(const char *port, bool gso, const char *logfile, const char *cc, 
         server_ctx.init_cc = &quicly_cc_cubic_init;
     }
 
-    set_iw(iw, server_ctx.transport_params.max_udp_payload_size);
-    
     if (gso) {
         enable_gso();
     }


### PR DESCRIPTION
https://github.com/rbruenig/qperf/pull/9 updated quicly, requiring changes in the cc constructor. The initial congestion window `initcwnd` was previously set within the cc constructor which is not longer the case, thus breaking the `--iw` option.
This is fixed by configuring the `initcwnd` within `quicly_ctx`.